### PR TITLE
feat(react): remove empty elements from rendering

### DIFF
--- a/.changeset/long-dancers-reply.md
+++ b/.changeset/long-dancers-reply.md
@@ -1,0 +1,5 @@
+---
+'@graphcms/rich-text-types': patch
+---
+
+- Add `RemoveEmptyElementType`

--- a/.changeset/rare-ligers-appear.md
+++ b/.changeset/rare-ligers-appear.md
@@ -1,0 +1,7 @@
+---
+'@graphcms/rich-text-react-renderer': patch
+---
+
+⚡️ Improvements:
+
+- feat(react): remove empty headings from rendering

--- a/package.json
+++ b/package.json
@@ -44,11 +44,11 @@
   "size-limit": [
     {
       "path": "packages/react/dist/rich-text-react-renderer.cjs.production.min.js",
-      "limit": "4.5 KB"
+      "limit": "5 KB"
     },
     {
       "path": "packages/react/dist/rich-text-react-renderer.esm.js",
-      "limit": "4.5 KB"
+      "limit": "5 KB"
     },
     {
       "path": "packages/types/dist/rich-text-types.cjs.production.min.js",

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -140,71 +140,9 @@ Below you can check the full list of elements you can customize, alongside the p
 - `code`
   - `children`: ReactNode;
 
-### Remove empty elements
+### Removal of empty elements
 
-By default the `RichText` component does not render all elements if their children are empty or just contain a text node with no content (whitespace excluded), you can pass a `removers` prop to `RichText` component to contorl whether to render a element if it's content is empty or not. Let's see an example:
-
-```tsx
-import { RichText } from '@graphcms/rich-text-react-renderer';
-
-const App = () => {
-  return (
-    <div>
-      <RichText
-        children={content}
-        removers={{
-          h2: false,
-          h3: true,
-          p: false,
-        }}
-      />
-    </div>
-  );
-};
-```
-
-Below you can check the full list of elements you can remove from rendering if empty, alongside with their default setting.
-
-- `a`:
-  - `true`
-- `class`:
-  - `true`
-- `h1`:
-  - `true`
-- `h2`:
-  - `true`
-- `h3`:
-  - `true`
-- `h4`:
-  - `true`
-- `h5`:
-  - `true`
-- `h6`:
-  - `true`
-- `p`:
-  - `false`
-- `li`:
-  - `true`
-- `table`:
-  - `true`
-- `table_head`:
-  - `true`
-- `table_body`:
-  - `true`
-- `table_row`:
-  - `false`
-- `table_cell`:
-  - `false`
-- `blockquote`:
-  - `true`
-- `bold`:
-  - `true`
-- `italic`:
-  - `true`
-- `underline`:
-  - `true`
-- `code`:
-  - `true`
+By default, we remove empty headings from the element list to prevent SEO issues.
 
 ### TypeScript
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -140,7 +140,7 @@ Below you can check the full list of elements you can customize, alongside the p
 - `code`
   - `children`: ReactNode;
 
-### Removal of empty elements
+### Empty elements
 
 By default, we remove empty headings from the element list to prevent SEO issues.
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -140,6 +140,72 @@ Below you can check the full list of elements you can customize, alongside the p
 - `code`
   - `children`: ReactNode;
 
+### Remove empty elements
+
+By default the `RichText` component does not render all elements if their children are empty or just contain a text node with no content (whitespace excluded), you can pass a `removers` prop to `RichText` component to contorl whether to render a element if it's content is empty or not. Let's see an example:
+
+```tsx
+import { RichText } from '@graphcms/rich-text-react-renderer';
+
+const App = () => {
+  return (
+    <div>
+      <RichText
+        children={content}
+        removers={{
+          h2: false,
+          h3: true,
+          p: false,
+        }}
+      />
+    </div>
+  );
+};
+```
+
+Below you can check the full list of elements you can remove from rendering if empty, alongside with their default setting.
+
+- `a`:
+  - `true`
+- `class`:
+  - `true`
+- `h1`:
+  - `true`
+- `h2`:
+  - `true`
+- `h3`:
+  - `true`
+- `h4`:
+  - `true`
+- `h5`:
+  - `true`
+- `h6`:
+  - `true`
+- `p`:
+  - `false`
+- `li`:
+  - `true`
+- `table`:
+  - `true`
+- `table_head`:
+  - `true`
+- `table_body`:
+  - `true`
+- `table_row`:
+  - `false`
+- `table_cell`:
+  - `false`
+- `blockquote`:
+  - `true`
+- `bold`:
+  - `true`
+- `italic`:
+  - `true`
+- `underline`:
+  - `true`
+- `code`:
+  - `true`
+
 ### TypeScript
 
 If you are using TypeScript in your project, we highly recommend you install the `@graphcms/rich-text-types` package. It contains types for the elements, alongside the props accepted by each of them. You can use them in your application to create custom components.

--- a/packages/react/src/RichText.tsx
+++ b/packages/react/src/RichText.tsx
@@ -18,11 +18,9 @@ import { RenderText } from './RenderText';
 
 function RenderNode({
   node,
-  removers,
   renderers,
 }: {
   node: Node;
-  removers?: RemoveEmptyElementType;
   renderers?: NodeRendererType;
 }) {
   if (isText(node)) {
@@ -30,9 +28,7 @@ function RenderNode({
   }
 
   if (isElement(node)) {
-    return (
-      <RenderElement element={node} removers={removers} renderers={renderers} />
-    );
+    return <RenderElement element={node} renderers={renderers} />;
   }
 
   const { type } = node as ElementNode;
@@ -48,18 +44,18 @@ function RenderNode({
 
 function RenderElement({
   element,
-  removers,
   renderers,
 }: {
   element: ElementNode;
-  removers?: RemoveEmptyElementType;
   renderers?: NodeRendererType;
 }) {
   const { children, type, ...rest } = element;
 
   if (
-    removers?.[elementKeys[type] as keyof RemoveEmptyElementType] &&
-    !children.filter((child) => child.text !== '').length
+    defaultRemoveEmptyElements?.[
+      elementKeys[type] as keyof RemoveEmptyElementType
+    ] &&
+    children[0].text === ''
   ) {
     return <Fragment />;
   }
@@ -69,11 +65,7 @@ function RenderElement({
   if (NodeRenderer) {
     return (
       <NodeRenderer {...rest}>
-        <RichText
-          content={children as ElementNode[]}
-          removers={removers}
-          renderers={renderers}
-        />
+        <RichText content={children as ElementNode[]} renderers={renderers} />
       </NodeRenderer>
     );
   }
@@ -81,19 +73,10 @@ function RenderElement({
   return <Fragment />;
 }
 
-export function RichText({
-  content,
-  removers: emptyItemRemoveList,
-  renderers: resolvers,
-}: RichTextProps) {
+export function RichText({ content, renderers: resolvers }: RichTextProps) {
   const renderers: NodeRendererType = {
     ...defaultElements,
     ...resolvers,
-  };
-
-  const removers: RemoveEmptyElementType = {
-    ...defaultRemoveEmptyElements,
-    ...emptyItemRemoveList,
   };
 
   if (__DEV__ && !content) {
@@ -115,14 +98,7 @@ export function RichText({
   return (
     <>
       {elements.map((node, index) => {
-        return (
-          <RenderNode
-            node={node}
-            removers={removers}
-            renderers={renderers}
-            key={index}
-          />
-        );
+        return <RenderNode node={node} renderers={renderers} key={index} />;
       })}
     </>
   );

--- a/packages/react/src/defaultElements.tsx
+++ b/packages/react/src/defaultElements.tsx
@@ -36,26 +36,12 @@ export const defaultElements: Required<NodeRendererType> = {
 };
 
 export const defaultRemoveEmptyElements: Required<RemoveEmptyElementType> = {
-  a: true,
-  class: true,
   h1: true,
   h2: true,
   h3: true,
   h4: true,
   h5: true,
   h6: true,
-  p: false,
-  li: true,
-  table: true,
-  table_head: true,
-  table_body: true,
-  table_row: false,
-  table_cell: false,
-  blockquote: true,
-  bold: true,
-  italic: true,
-  underline: true,
-  code: true,
 };
 
 export const elementKeys: { [key: string]: string } = {

--- a/packages/react/src/defaultElements.tsx
+++ b/packages/react/src/defaultElements.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
-import { NodeRendererType } from '@graphcms/rich-text-types';
+import {
+  NodeRendererType,
+  RemoveEmptyElementType,
+} from '@graphcms/rich-text-types';
 
 import { IFrame, Image, Video, Class, Link } from './elements';
 
@@ -30,6 +33,29 @@ export const defaultElements: Required<NodeRendererType> = {
   underline: ({ children }) => <u>{children}</u>,
   code: ({ children }) => <code>{children}</code>,
   list_item_child: ({ children }) => <>{children}</>,
+};
+
+export const defaultRemoveEmptyElements: Required<RemoveEmptyElementType> = {
+  a: true,
+  class: true,
+  h1: true,
+  h2: true,
+  h3: true,
+  h4: true,
+  h5: true,
+  h6: true,
+  p: false,
+  li: true,
+  table: true,
+  table_head: true,
+  table_body: true,
+  table_row: false,
+  table_cell: false,
+  blockquote: true,
+  bold: true,
+  italic: true,
+  underline: true,
+  code: true,
 };
 
 export const elementKeys: { [key: string]: string } = {

--- a/packages/react/test/RichText.test.tsx
+++ b/packages/react/test/RichText.test.tsx
@@ -57,18 +57,13 @@ describe('@graphcms/rich-text-react-renderer', () => {
   });
 
   it('renders content correctly if received a object with empty children', () => {
-    const { container } = render(
-      <RichText content={emptyContent} removers={{ blockquote: false }} />
-    );
+    const { container } = render(<RichText content={emptyContent} />);
 
     expect(container).toMatchInlineSnapshot(`
       <div>
-        <p>
-          
-        </p>
-        <blockquote>
-          
-        </blockquote>
+        <h5>
+          Hello World!
+        </h5>
       </div>
     `);
   });

--- a/packages/react/test/RichText.test.tsx
+++ b/packages/react/test/RichText.test.tsx
@@ -10,6 +10,7 @@ import {
   listContent,
   iframeContent,
   inlineContent,
+  emptyContent,
 } from './content';
 
 describe('@graphcms/rich-text-react-renderer', () => {
@@ -51,6 +52,23 @@ describe('@graphcms/rich-text-react-renderer', () => {
             Hello World!
           </b>
         </p>
+      </div>
+    `);
+  });
+
+  it('renders content correctly if received a object with empty children', () => {
+    const { container } = render(
+      <RichText content={emptyContent} removers={{ blockquote: false }} />
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <p>
+          
+        </p>
+        <blockquote>
+          
+        </blockquote>
       </div>
     `);
   });

--- a/packages/react/test/content.ts
+++ b/packages/react/test/content.ts
@@ -22,18 +22,10 @@ export const emptyContent: RichTextContent = [
     ],
   },
   {
-    type: 'paragraph',
+    type: 'heading-five',
     children: [
       {
-        text: '',
-      },
-    ],
-  },
-  {
-    type: 'block-quote',
-    children: [
-      {
-        text: '',
+        text: 'Hello World!',
       },
     ],
   },

--- a/packages/react/test/content.ts
+++ b/packages/react/test/content.ts
@@ -12,6 +12,33 @@ export const defaultContent: RichTextContent = [
   },
 ];
 
+export const emptyContent: RichTextContent = [
+  {
+    type: 'heading-two',
+    children: [
+      {
+        text: '',
+      },
+    ],
+  },
+  {
+    type: 'paragraph',
+    children: [
+      {
+        text: '',
+      },
+    ],
+  },
+  {
+    type: 'block-quote',
+    children: [
+      {
+        text: '',
+      },
+    ],
+  },
+];
+
 export const inlineContent: RichTextContent = [
   {
     type: 'paragraph',

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -116,6 +116,7 @@ export type RichTextContent =
 
 export type RichTextProps = {
   content: RichTextContent;
+  removers?: RemoveEmptyElementType;
   renderers?: NodeRendererType;
 };
 
@@ -165,6 +166,29 @@ export interface NodeRendererType {
   italic?: DefaultNodeRenderer;
   underline?: DefaultNodeRenderer;
   code?: DefaultNodeRenderer;
+}
+
+export interface RemoveEmptyElementType {
+  a?: Boolean;
+  class?: Boolean;
+  h1?: Boolean;
+  h2?: Boolean;
+  h3?: Boolean;
+  h4?: Boolean;
+  h5?: Boolean;
+  h6?: Boolean;
+  p?: Boolean;
+  li?: Boolean;
+  table?: Boolean;
+  table_head?: Boolean;
+  table_body?: Boolean;
+  table_row?: Boolean;
+  table_cell?: Boolean;
+  blockquote?: Boolean;
+  bold?: Boolean;
+  italic?: Boolean;
+  underline?: Boolean;
+  code?: Boolean;
 }
 
 export * from './util/isElement';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -116,7 +116,6 @@ export type RichTextContent =
 
 export type RichTextProps = {
   content: RichTextContent;
-  removers?: RemoveEmptyElementType;
   renderers?: NodeRendererType;
 };
 
@@ -169,26 +168,12 @@ export interface NodeRendererType {
 }
 
 export interface RemoveEmptyElementType {
-  a?: Boolean;
-  class?: Boolean;
   h1?: Boolean;
   h2?: Boolean;
   h3?: Boolean;
   h4?: Boolean;
   h5?: Boolean;
   h6?: Boolean;
-  p?: Boolean;
-  li?: Boolean;
-  table?: Boolean;
-  table_head?: Boolean;
-  table_body?: Boolean;
-  table_row?: Boolean;
-  table_cell?: Boolean;
-  blockquote?: Boolean;
-  bold?: Boolean;
-  italic?: Boolean;
-  underline?: Boolean;
-  code?: Boolean;
 }
 
 export * from './util/isElement';


### PR DESCRIPTION
This PR adds support for removing specified elements if they would be rendered empty

Maybe the naming of the property determining whether an empty element should be rendered or not could be changed, it's not as descriptive as it could be. (I did not find another name though)